### PR TITLE
fix: 加载存档时版本检查提示被动画覆盖

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@
 1. **克隆项目**
 ```bash
 git clone <repository-url>
-cd AI-game-test
+cd AI-text-adv
 ```
 
 2. **安装依赖**

--- a/main.py
+++ b/main.py
@@ -177,7 +177,7 @@ def manage_auto_saves(game_save_dir, save_name="autosave"):
         print(f"自动存档管理失败: {e}")
 
 
-def load_game(game_engine, save_name="autosave", filename=None, game_id=None):
+def load_game(game_engine, save_name="autosave", filename=None, game_id=None, loading_animation=None):
     """
     从文件加载游戏状态
     """
@@ -221,6 +221,8 @@ def load_game(game_engine, save_name="autosave", filename=None, game_id=None):
 
         # 恢复游戏状态
         if save_data["version"] != VERSION:
+            if loading_animation:
+                loading_animation.stop_animation()
             tmp = input(
                 f"\n[警告]:不匹配的版本号(存档{save_data['version']} -- 游戏{VERSION})\n 强制读取？(y/n)")
             if tmp.lower() != "y":
@@ -855,7 +857,7 @@ def new_game(no_auto_load=False):
     anime_loader.start_animation("spinner", message="读取中")
     show_init_resp = False
     if not no_auto_load:
-        loadsuccess, _, message = load_game(GAME)
+        loadsuccess, _, message = load_game(GAME, loading_animation=anime_loader)
         print(message)
     else:
         loadsuccess = False


### PR DESCRIPTION
fix issue #4

## Summary by Sourcery

在加载存档时，在显示版本不匹配警告之前停止加载动画，并在 README 中更正项目目录名称。

Bug Fixes:
- 防止在游戏加载过程中，存档版本不匹配警告提示被加载动画遮挡。

Documentation:
- 更新 README，在克隆仓库后使用正确的项目目录名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stop the loading animation before showing a version mismatch warning when loading a save, and correct the project directory name in the README.

Bug Fixes:
- Prevent the save version mismatch warning prompt from being obscured by the loading animation during game load.

Documentation:
- Update the README to use the correct project directory name after cloning the repository.

</details>